### PR TITLE
Remove tests for Python 3.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: python
 python:
   - "2.6"
   - "2.7"
-  - "3.2"
   - "3.3"
   - "3.4"
 


### PR DESCRIPTION
Removed from travis build, and support for Python 3.2, as not supported by requests.
