### PR TITLE
Introduce two types of client, Fetch and Search

### DIFF
--- a/docs/api/clients.rst
+++ b/docs/api/clients.rst
@@ -1,21 +1,13 @@
 clients
-==============
+=======
 
 .. automodule:: pybomb.clients
     :members:
     :undoc-members:
     :show-inheritance:
 
-client
---------------------------
-
-.. automodule:: pybomb.clients.client
-    :members:
-    :undoc-members:
-    :show-inheritance:
-
 games_client
----------------------------
+------------
 
 .. automodule:: pybomb.clients.games_client
     :members:
@@ -23,9 +15,43 @@ games_client
     :show-inheritance:
 
 game_client
----------------------------
+-----------
 
 .. automodule:: pybomb.clients.game_client
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+base
+====
+
+.. automodule:: pybomb.clients.base
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+client
+------
+
+ .. automodule:: pybomb.clients.base.client
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+fetch_client
+------------
+
+ .. automodule:: pybomb.clients.base.fetch_client
+    :members:
+    :undoc-members:
+    :show-inheritance:
+
+
+search_client
+-------------
+
+ .. automodule:: pybomb.clients.base.search_client
     :members:
     :undoc-members:
     :show-inheritance:

--- a/src/pybomb/clients/base/__init__.py
+++ b/src/pybomb/clients/base/__init__.py
@@ -1,0 +1,1 @@
+"""Base Clients module for base clients used to create GB API clients."""

--- a/src/pybomb/clients/base/fetch_client.py
+++ b/src/pybomb/clients/base/fetch_client.py
@@ -1,0 +1,26 @@
+"""Base client to extend to create fetch clients for endpoints of the GiantBomb API."""
+from typing import Dict, Union
+
+from requests import get, Response as RequestsResponse
+
+from pybomb.clients.base.client import Client
+
+
+class FetchClient(Client):
+    """Base class for fetch GB API resource clients."""
+
+    def _query_api(self, params: Dict[str, Union[str, int]]) -> RequestsResponse:
+        """Handle actual query to GB API.
+
+        Args:
+            params: All requests and required resource query parameters
+
+        Returns:
+            The raw requests Response from the GB call
+        """
+        id = params.pop("id")
+        return get(
+            self.URI_BASE + self.RESOURCE_NAME + "/{0}".format(id),
+            params=params,
+            headers=self._headers,
+        )

--- a/src/pybomb/clients/base/search_client.py
+++ b/src/pybomb/clients/base/search_client.py
@@ -1,0 +1,23 @@
+"""Base client to extend to create search clients for endpoints of the GiantBomb API."""
+from typing import Dict, Union
+
+from requests import get, Response as RequestsResponse
+
+from pybomb.clients.base.client import Client
+
+
+class SearchClient(Client):
+    """Base class for search GB API resource clients."""
+
+    def _query_api(self, params: Dict[str, Union[str, int]]) -> RequestsResponse:
+        """Handle actual query to GB API.
+
+        Args:
+            params: All requests and required resource query parameters
+
+        Returns:
+            The raw requests Response from the GB call
+        """
+        return get(
+            self.URI_BASE + self.RESOURCE_NAME, params=params, headers=self._headers
+        )

--- a/src/pybomb/clients/game_client.py
+++ b/src/pybomb/clients/game_client.py
@@ -4,11 +4,12 @@ https://www.giantbomb.com/api/documentation#toc-0-16
 """
 from typing import Dict, List, Union
 
-from pybomb.clients.client import Client, ResponseParam
+from pybomb.clients.base.client import ResponseParam
+from pybomb.clients.base.fetch_client import FetchClient
 from pybomb.response import Response
 
 
-class GameClient(Client):
+class GameClient(FetchClient):
     """Client for the 'game' API resource."""
 
     RESOURCE_NAME = "game"
@@ -75,6 +76,6 @@ class GameClient(Client):
 
             game_params["field_list"] = field_list
 
-        response = self._query(game_params, direct=True)
+        response = self._query(game_params)
 
         return response

--- a/src/pybomb/clients/games_client.py
+++ b/src/pybomb/clients/games_client.py
@@ -4,11 +4,12 @@ https://www.giantbomb.com/api/documentation#toc-0-17
 """
 from typing import Any, Dict, List, Optional, Union
 
-from pybomb.clients.client import Client, ResponseParam
+from pybomb.clients.base.client import ResponseParam
+from pybomb.clients.base.search_client import SearchClient
 from pybomb.response import Response
 
 
-class GamesClient(Client):
+class GamesClient(SearchClient):
     """Client for the 'games' API resource."""
 
     RESOURCE_NAME = "games"

--- a/src/pybomb/response.py
+++ b/src/pybomb/response.py
@@ -1,5 +1,5 @@
 """The response types and factories for PyBomb."""
-from typing import NamedTuple, Union
+from typing import NamedTuple, Optional
 
 from requests import Response as RequestsResponse
 
@@ -10,23 +10,39 @@ class Response(NamedTuple):
     uri: str
     num_page_results: int
     num_total_results: int
-    results: Union[list, dict]
+    results: list
+    result: Optional[dict]
 
     @classmethod
     def from_response_data(cls, response_data: RequestsResponse) -> "Response":
         """Response factory.
 
+        If the response is from a fetch client and "results" is not wrapped in
+        a list, the single result will be stored in results in a list and the
+        original result will be added to result.
+
+        If the response is from a search client and "results" is a list, this list
+        will be stored in results and result will be empty.
+
+        Either way, results will always hold the results in list format.
+
         Args:
             response_data: Raw request response of API call
 
         Returns:
-            A PyBomb Response containing the raw response data
+            A PyBomb Response containing the raw response data.
         """
         response_json = response_data.json()
 
-        return cls(
+        cls_args = [
             response_data.url,
             response_json["number_of_page_results"],
             response_json["number_of_total_results"],
-            response_json["results"],
-        )
+        ]
+
+        if isinstance(response_json["results"], dict):
+            cls_args.extend(([response_json["results"]], response_json["results"]))
+        else:
+            cls_args.extend((response_json["results"], None))
+
+        return cls(*cls_args)

--- a/tests/test_clients/test_game.py
+++ b/tests/test_clients/test_game.py
@@ -71,7 +71,8 @@ class TestGameClient:
         assert res.uri == mock_response.url
 
         mock_response_json = mock_response.json()
-        assert res.results == mock_response_json["results"]
+        assert res.results == [mock_response_json["results"]]
+        assert res.result == mock_response_json["results"]
 
         assert res.num_page_results == (mock_response_json["number_of_page_results"])
 

--- a/tests/test_clients/test_game.py
+++ b/tests/test_clients/test_game.py
@@ -24,7 +24,7 @@ class TestGameClient:
     @pytest.fixture
     def mock_requests_get(self) -> MagicMock:
         """Request GET test mock."""
-        with patch("pybomb.clients.client.get") as req_mock:
+        with patch("pybomb.clients.base.fetch_client.get") as req_mock:
             yield req_mock
 
     @pytest.fixture

--- a/tests/test_clients/test_games.py
+++ b/tests/test_clients/test_games.py
@@ -133,6 +133,7 @@ class TestGamesClient:
 
             mock_response_json = mock_response.json()
             assert res.results == mock_response_json["results"]
+            assert res.result is None
 
             assert res.num_page_results == (
                 mock_response_json["number_of_page_results"]
@@ -218,6 +219,7 @@ class TestGamesClient:
 
             mock_response_json = mock_response.json()
             assert res.results == mock_response_json["results"]
+            assert res.result is None
 
             assert res.num_page_results == (
                 mock_response_json["number_of_page_results"]

--- a/tests/test_clients/test_games.py
+++ b/tests/test_clients/test_games.py
@@ -28,7 +28,7 @@ class TestGamesClient:
     @pytest.fixture
     def mock_requests_get(self) -> MagicMock:
         """Request GET test mock."""
-        with patch("pybomb.clients.client.get") as req_mock:
+        with patch("pybomb.clients.base.search_client.get") as req_mock:
             yield req_mock
 
     @pytest.fixture


### PR DESCRIPTION
* Add separate base clients for fetch and search clients
* `Response.results` is now consistently a List
* When fetching a single response by ID, that single response can now be accessed from `Response.result`
